### PR TITLE
Add CI workflow to ensure the submodule is up to date

### DIFF
--- a/.github/workflows/check_baseapp_submodule.yml
+++ b/.github/workflows/check_baseapp_submodule.yml
@@ -24,4 +24,4 @@ jobs:
         run: |
           git submodule update --init --recursive
           git submodule update --remote --recursive
-          git diff --exit-code
+          git diff --exit-code || { echo "The submodule is not up to date"; exit 1; }

--- a/.github/workflows/check_baseapp_submodule.yml
+++ b/.github/workflows/check_baseapp_submodule.yml
@@ -1,0 +1,27 @@
+name: Check that the submodule is up to date
+
+# This workflow ensures that the submodule is up to date with the 'baseapp' branch
+# of the https://github.com/LedgerHQ/app-bitcoin-new repository.
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - master
+      - main
+      - develop
+  pull_request:
+
+jobs:
+  check_submodule:
+    name: Check submodule
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone
+        uses: actions/checkout@v4
+
+      - name: Compare submodule with remote branch
+        run: |
+          git submodule update --init --recursive
+          git submodule update --remote --recursive
+          git diff --exit-code


### PR DESCRIPTION
This adds a workflow that fails if the submodule is not up to date.

[Example failing run](https://github.com/LedgerHQ/app-btcext-boilerplate/actions/runs/13989504427/job/39170095248?pr=2)