### PR TITLE
Baseapp at 2026-03-03 (to support Clang 21)

### DIFF
--- a/src/display.c
+++ b/src/display.c
@@ -2,7 +2,7 @@
 
 #include "../bitcoin_app_base/src/ui/display.h"
 #include "../bitcoin_app_base/src/ui/menu.h"
-#include "io.h"
+#include "io_ext.h"
 #include "nbgl_use_case.h"
 
 static void review_choice(bool approved) {


### PR DESCRIPTION
- [x] testing with https://github.com/LedgerHQ/app-bitcoin-new/tree/baseapp_at_2026-03-03
- [x] in https://github.com/LedgerHQ/app-bitcoin-new/
    - [x] `baseapp` rename to `baseapp_2.4.5`
    - [x] `baseapp_at_2026-03-03` rename to `baseapp`
- [ ] switch to `baseapp`