### PR TITLE
Baseapp update 2026-06-04

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -6,6 +6,7 @@
 #include "../bitcoin_app_base/src/handler/lib/get_merkleized_map.h"
 #include "../bitcoin_app_base/src/handler/lib/get_merkleized_map_value.h"
 #include "../bitcoin_app_base/src/handler/sign_psbt.h"
+#include "../bitcoin_app_base/src/handler/sign_psbt/sign_input.h"
 #include "../bitcoin_app_base/src/handler/sign_psbt/txhashes.h"
 #include "../bitcoin_app_base/src/crypto.h"
 


### PR DESCRIPTION
- [x] switched to https://github.com/LedgerHQ/app-bitcoin-new/tree/baseapp_candidate_2026-06-04 that is `baseapp` rebased on current `develop` (cdc959d13002e876404e47fb99dba25a13827fe2)  (still te same 8 commits)
- [x]  btcext adapted

**To be reviewed:**
- [x]  to be reviewed https://github.com/LedgerHQ/app-bitcoin-new/compare/develop...baseapp_candidate_2026-06-04
- [x]  to be reviewed  https://github.com/LedgerHQ/app-bitcoin-new/compare/baseapp..baseapp_candidate_2026-06-04

**If OK:**
- [x]  to replace https://github.com/LedgerHQ/app-bitcoin-new/tree/baseapp by https://github.com/LedgerHQ/app-bitcoin-new/tree/baseapp_candidate_2026-06-04
- [x] to switch the sub-module in this repository to the new `baseapp` - was not even needed as I swapped the branches. 
